### PR TITLE
refactor items to attach to character on pick-up

### DIFF
--- a/Assets/Prefabs/Item/Item1.prefab
+++ b/Assets/Prefabs/Item/Item1.prefab
@@ -20,9 +20,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4627135151277002}
   - component: {fileID: 212130292027760952}
-  - component: {fileID: 50733136465689456}
-  - component: {fileID: 58023524918371754}
-  - component: {fileID: 114401820450772906}
   m_Layer: 0
   m_Name: Item1
   m_TagString: Item
@@ -30,6 +27,36 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1385256689038480
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4409889704049314}
+  - component: {fileID: 114529170940012548}
+  - component: {fileID: 58224786073601358}
+  m_Layer: 0
+  m_Name: Speed
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4409889704049314
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1385256689038480}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4627135151277002}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4627135151277002
 Transform:
   m_ObjectHideFlags: 1
@@ -37,38 +64,19 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1034290445990190}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.96, y: -3.46, z: -0.1171875}
+  m_LocalPosition: {x: -23.72, y: -2.59, z: -0.1171875}
   m_LocalScale: {x: 4.2973876, y: 4.265789, z: 1.1235}
-  m_Children: []
+  m_Children:
+  - {fileID: 4409889704049314}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!50 &50733136465689456
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1034290445990190}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
---- !u!58 &58023524918371754
+--- !u!58 &58224786073601358
 CircleCollider2D:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1034290445990190}
+  m_GameObject: {fileID: 1385256689038480}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -77,13 +85,13 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.10000002
---- !u!114 &114401820450772906
+  m_Radius: 0.1
+--- !u!114 &114529170940012548
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1034290445990190}
+  m_GameObject: {fileID: 1385256689038480}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d4f47b9692911ab4d9f664b28fc617a4, type: 3}
@@ -123,7 +131,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 903851429
-  m_SortingLayer: 3
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
   m_Color: {r: 0.32028666, g: 0.745283, b: 0.2988163, a: 1}

--- a/Assets/Prefabs/Item/Item2.prefab
+++ b/Assets/Prefabs/Item/Item2.prefab
@@ -20,9 +20,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4217349986301136}
   - component: {fileID: 212450457454395802}
-  - component: {fileID: 50760231657300714}
-  - component: {fileID: 58427630675984864}
-  - component: {fileID: 114902465198471620}
   m_Layer: 0
   m_Name: Item2
   m_TagString: Item
@@ -30,6 +27,36 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1708857076635120
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4056604798766730}
+  - component: {fileID: 114862595037495964}
+  - component: {fileID: 58324349608640844}
+  m_Layer: 0
+  m_Name: DamageUp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4056604798766730
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1708857076635120}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4217349986301136}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4217349986301136
 Transform:
   m_ObjectHideFlags: 1
@@ -37,38 +64,19 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1397161501090052}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2, y: 4, z: -0.1171875}
+  m_LocalPosition: {x: -22.115791, y: -2.4379141, z: -0.1171875}
   m_LocalScale: {x: 4.2973876, y: 4.265789, z: 1.1235}
-  m_Children: []
+  m_Children:
+  - {fileID: 4056604798766730}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!50 &50760231657300714
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1397161501090052}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
---- !u!58 &58427630675984864
+--- !u!58 &58324349608640844
 CircleCollider2D:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1397161501090052}
+  m_GameObject: {fileID: 1708857076635120}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -77,13 +85,13 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.10000002
---- !u!114 &114902465198471620
+  m_Radius: 0.1
+--- !u!114 &114862595037495964
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1397161501090052}
+  m_GameObject: {fileID: 1708857076635120}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 84420a8f1cc8c5347ad7ff273b15a6b5, type: 3}

--- a/Assets/Prefabs/Item/Item3.prefab
+++ b/Assets/Prefabs/Item/Item3.prefab
@@ -20,12 +20,26 @@ GameObject:
   m_Component:
   - component: {fileID: 4098659198660048}
   - component: {fileID: 212199833700779476}
-  - component: {fileID: 50978087796889520}
-  - component: {fileID: 58351943800457696}
-  - component: {fileID: 114109745849947466}
   m_Layer: 0
   m_Name: Item3
   m_TagString: Item
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1158519392964992
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4639222587461432}
+  - component: {fileID: 114661586385708098}
+  - component: {fileID: 58301929331401632}
+  m_Layer: 0
+  m_Name: HealthDown
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -37,38 +51,32 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1075546921227186}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.96, y: -3.46, z: -0.1171875}
+  m_LocalPosition: {x: -20.015156, y: -2.8000925, z: -0.1171875}
   m_LocalScale: {x: 4.2973876, y: 4.265789, z: 1.1235}
-  m_Children: []
+  m_Children:
+  - {fileID: 4639222587461432}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!50 &50978087796889520
-Rigidbody2D:
-  serializedVersion: 4
+--- !u!4 &4639222587461432
+Transform:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1075546921227186}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
---- !u!58 &58351943800457696
+  m_GameObject: {fileID: 1158519392964992}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4098659198660048}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &58301929331401632
 CircleCollider2D:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1075546921227186}
+  m_GameObject: {fileID: 1158519392964992}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -77,13 +85,13 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.10000002
---- !u!114 &114109745849947466
+  m_Radius: 0.1
+--- !u!114 &114661586385708098
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1075546921227186}
+  m_GameObject: {fileID: 1158519392964992}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 88dd6ac8132c8c14cbd483cf42e18b04, type: 3}
@@ -123,7 +131,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 903851429
-  m_SortingLayer: 3
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
   m_Color: {r: 0.009433985, g: 0.009433985, b: 0.009433985, a: 1}

--- a/Assets/Scripts/Character/Character.cs
+++ b/Assets/Scripts/Character/Character.cs
@@ -14,7 +14,6 @@ public class Character : MonoBehaviour {
 	public float slapRange = 2f;
 	public float possessRange = 6f;
 	
-
     private float moveForce = 51f;
 	public float maxSpeed = 3f;
 	public float jumpForce = 5000f;
@@ -22,6 +21,8 @@ public class Character : MonoBehaviour {
 	public bool slapping = false;
 	public bool slapDebounce = false;
 	private bool grounded = true;
+
+	public List<Item> inventory = new List<Item>();
 
 	public Transform groundCheck;
 
@@ -31,7 +32,6 @@ public class Character : MonoBehaviour {
 	public GameObject possessFab;
 
 	private bool facingRight = true;
-
 
 	// Use this for initialization
 	void Awake () {
@@ -205,5 +205,12 @@ public class Character : MonoBehaviour {
 
 	void drainHealth() {
 		TakeDamage(heathMinus);
+	}
+
+	public void Pickup(GameObject itemObject) {
+		Item item = itemObject.GetComponent<Item>();
+		inventory.Add(item);
+		itemObject.transform.parent = gameObject.transform;
+		item.OnPickup(this);
 	}
 }

--- a/Assets/Scripts/Item/Item.cs
+++ b/Assets/Scripts/Item/Item.cs
@@ -4,8 +4,6 @@ using UnityEngine;
 
 public abstract class Item : MonoBehaviour {
 
-	public Character character;
-
 	// Use this for initialization
 	void Start () {
 		
@@ -19,13 +17,14 @@ public abstract class Item : MonoBehaviour {
 	void OnTriggerEnter2D(Collider2D col) {
         Debug.Log("Collision on the item");
 		if (col.tag == "Character") {
-			// Item effect gets added here for now it will just be removed
-			character = col.gameObject.GetComponent<Character>();
-			ModifyCharacter();
-			Destroy(gameObject);
-			
+			GameObject parent = transform.parent.gameObject;
+
+			Character character = col.gameObject.GetComponent<Character>();
+			character.Pickup(gameObject);
+			GetComponent<Collider2D>().enabled = false;
+			Destroy(parent);
 		}
 	}
 
-	public abstract void ModifyCharacter();
+	public abstract void OnPickup(Character character);
 }

--- a/Assets/Scripts/Item/Item1.cs
+++ b/Assets/Scripts/Item/Item1.cs
@@ -13,7 +13,8 @@ public class Item1 : Item {
 		
 	}
 
-	public override void ModifyCharacter() {
+	public override void OnPickup(Character character) {
         character.maxSpeed += 3f;
-    }
+	}
+
 }

--- a/Assets/Scripts/Item/Item2.cs
+++ b/Assets/Scripts/Item/Item2.cs
@@ -13,7 +13,8 @@ public class Item2 : Item {
 	void Update () {
 		
 	}
-	public override void ModifyCharacter() {
+	
+	public override void OnPickup(Character character) {
 		character.slapDamage *= 2;
 		character.spewDamage *= 2;
 	}

--- a/Assets/Scripts/Item/Item3.cs
+++ b/Assets/Scripts/Item/Item3.cs
@@ -13,7 +13,8 @@ public class Item3 : Item {
 	void Update () {
 		
 	}
-	public override void ModifyCharacter() {
+	
+	public override void OnPickup(Character character) {
 		character.health -= 27;
 	}
 }


### PR DESCRIPTION
This changes item behavior to attach to the character on pickup instead of just making a one-time modification of some stats.

This will allow for some more complex item behavior by adding methods to handle modifying character actions as they happen (for example this would allow to more easily implement an item that changed the trajectory of spew attacks to add a random jitter).

I'm open to suggestions on how we want to implement this kind of thing, this is just a first stab at it