### PR TITLE
Fixing infinte jump if an enemy is on your head

### DIFF
--- a/Assets/FreePixelFood/Sprite/Food/Materials.meta
+++ b/Assets/FreePixelFood/Sprite/Food/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eb36a12ba3bec154994a765cb998f031
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Character/Character.cs
+++ b/Assets/Scripts/Character/Character.cs
@@ -278,9 +278,16 @@ public class Character : MonoBehaviour, OnLevelGoal
     }
 
     public void OnCollisionEnter2D(Collision2D col) {
-        if(col.gameObject.layer == LayerMask.NameToLayer("Ground")
-            || col.gameObject.layer == LayerMask.NameToLayer("Enemies")) {
-            grounded = true;
+        if(col.gameObject.layer == LayerMask.NameToLayer("Ground"))
+        {
+                grounded = true;
+        } else if (col.gameObject.layer == LayerMask.NameToLayer("Enemies"))
+        {
+            // Prevent infintily jumping if an enemy is on your head
+            if (transform.position.y > col.transform.position.y)
+            {
+                grounded = true;
+            }
         }
     }
 


### PR DESCRIPTION
Stopping infinite jump while an enemy is on your head.
Does not work for ground because in at least level 1, you can collide with the ground which is at y=0 while being at y=-2